### PR TITLE
Upgrade rest client / Use bundler MiniTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 rdoc
 *.gem
+.bundle
+Gemfile.lock
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+source 'https://y73zgYxxNNjH9Ps6W94d@gem.fury.io/me/'
+
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-source 'https://y73zgYxxNNjH9Ps6W94d@gem.fury.io/me/'
 
 gemspec

--- a/amazon_flex_pay.gemspec
+++ b/amazon_flex_pay.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency('rest-client', '~>1.6.1')
+  s.add_dependency('rest-client', '~>1.8.0')
   s.add_dependency('multi_xml', '>= 0.5.2')
   s.add_dependency('activesupport', '>= 3.0.14')
 

--- a/amazon_flex_pay.gemspec
+++ b/amazon_flex_pay.gemspec
@@ -1,5 +1,6 @@
-$LOAD_PATH << File.dirname(__FILE__) + '/lib'
-require 'amazon_flex_pay'
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'amazon_flex_pay/version'
 
 Gem::Specification.new do |s|
   s.name = 'amazon_flex_pay'
@@ -13,9 +14,15 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("lib/**/*") + %w(LICENSE README.rdoc Rakefile)
   s.test_files = Dir.glob("test/**/*")
 
+  s.require_paths = ["lib"]
+
   s.add_dependency('rest-client', '~>1.6.1')
   s.add_dependency('multi_xml', '>= 0.5.2')
   s.add_dependency('activesupport', '>= 3.0.14')
 
   s.add_development_dependency('mocha')
+  s.add_development_dependency("bundler", "~> 1.3")
+  s.add_development_dependency("rake")
+  s.add_development_dependency("rails", '3.2.5')
+  s.add_development_dependency "shoulda"
 end

--- a/lib/amazon_flex_pay.rb
+++ b/lib/amazon_flex_pay.rb
@@ -19,7 +19,6 @@ require_relative 'amazon_flex_pay/api'
 require_relative 'amazon_flex_pay/pipelines'
 
 module AmazonFlexPay
-  VERSION = '0.10.0'
   API_VERSION = '2011-09-20'
   PIPELINE_VERSION = '2009-01-09'
 

--- a/lib/amazon_flex_pay/version.rb
+++ b/lib/amazon_flex_pay/version.rb
@@ -1,3 +1,3 @@
 module AmazonFlexPay
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/lib/amazon_flex_pay/version.rb
+++ b/lib/amazon_flex_pay/version.rb
@@ -1,0 +1,3 @@
+module AmazonFlexPay
+  VERSION = '0.10.0'
+end

--- a/test/amazon_flex_pay/api_test.rb
+++ b/test/amazon_flex_pay/api_test.rb
@@ -376,12 +376,12 @@ class AmazonFlexPay::APITest < AmazonFlexPay::Test
 
   should "catch and parse errors" do
     net_http_res = stub(:code => 400)
-    http_response = RestClient::Response.create(error_response, net_http_res, nil)
+    request = TestRequest.new(:foo => 'bar')
+    http_response = RestClient::Response.create(error_response, net_http_res, nil, request)
     RestClient.expects(:get).raises(RestClient::BadRequest.new(http_response))
 
     error = nil
     begin
-      request = TestRequest.new(:foo => 'bar')
       AmazonFlexPay.send(:submit, request)
     rescue AmazonFlexPay::API::InvalidParams => e
       error = e
@@ -397,11 +397,11 @@ class AmazonFlexPay::APITest < AmazonFlexPay::Test
 
     ActiveSupport::Notifications.subscribed(callback, "amazon_flex_pay.api") do
       net_http_res = stub(:code => 400)
-      http_response = RestClient::Response.create(error_response, net_http_res, nil)
+      request = TestRequest.new(:foo => 'bar')
+      http_response = RestClient::Response.create(error_response, net_http_res, nil, request)
       RestClient.expects(:get).raises(RestClient::BadRequest.new(http_response))
 
       begin
-        request = TestRequest.new(:foo => 'bar')
         AmazonFlexPay.send(:submit, request)
       rescue AmazonFlexPay::API::Error
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,19 +1,19 @@
 # load the support libraries
-require 'test/unit'
 require 'rubygems'
-gem 'rails', '3.2.5'
-require 'mocha'
+require 'minitest/autorun'
+require 'minitest/spec'
+require 'minitest/pride'
+require 'mocha/setup'
+require 'shoulda'
 
 # load the gem
 require_relative '../lib/amazon_flex_pay'
 
 require_relative 'response_samples'
 
-class AmazonFlexPay::Test < Test::Unit::TestCase
-  def default_test; end # quiet Test::Unit
-
-  def self.should(name, &block) # very simple syntax
-    define_method("test_should_#{name.gsub(/[ -]/, '_')}", &block)
+class AmazonFlexPay::Test <  MiniTest::Unit::TestCase
+  def assert_nothing_raised(*)
+    yield
   end
 end
 


### PR DESCRIPTION
### WHAT

There is a CVE present for [rest-client versions <= 1.8.0](https://github.com/rest-client/rest-client/issues/369)

Adding bundler and minitest to make updating and running tests easier in the future.