### PR TITLE
Update rails dependency

### DIFF
--- a/amazon_flex_pay.gemspec
+++ b/amazon_flex_pay.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('mocha')
   s.add_development_dependency("bundler", "~> 1.3")
   s.add_development_dependency("rake")
-  s.add_development_dependency("rails", '3.2.5')
+  s.add_development_dependency("rails", '3.2.22.5')
   s.add_development_dependency "shoulda"
+  s.add_development_dependency "minitest"
 end

--- a/test/amazon_flex_pay/api/base_request_test.rb
+++ b/test/amazon_flex_pay/api/base_request_test.rb
@@ -34,7 +34,7 @@ class AmazonFlexPay::API::BaseRequestTest < AmazonFlexPay::Test
   end
 
   should "parameterize api requests" do
-    Time.stubs(:now).returns(Time.parse('Jan 1 2011')) # so the signature remains constant
+    Time.stubs(:now).returns(Date.parse('Jan 1 2011').to_time) # so the signature remains constant
 
     request = TestRequest.new(:foo => 'bar', :amount => {:value => '3.14', :currency_code => 'USD'})
     param = request.to_param

--- a/test/amazon_flex_pay/pipelines/base_test.rb
+++ b/test/amazon_flex_pay/pipelines/base_test.rb
@@ -16,7 +16,7 @@ class AmazonFlexPay::Pipelines::BaseTest < AmazonFlexPay::Test
   end
 
   should "parameterize signed pipelines" do
-    Time.stubs(:now).returns(Time.parse('Jan 1 2011')) # so the signature remains constant
+    Time.stubs(:now).returns(Date.parse('Jan 1 2011').to_time) # so the signature remains constant
 
     pipeline = TestPipeline.new(:foo => 'bar', :return_url => 'http://example.com/return')
     param = pipeline.to_param

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require_relative '../lib/amazon_flex_pay'
 
 require_relative 'response_samples'
 
-class AmazonFlexPay::Test <  MiniTest::Unit::TestCase
+class AmazonFlexPay::Test < Minitest::Test
   def assert_nothing_raised(*)
     yield
   end


### PR DESCRIPTION
Github's giving us a security audit warning for Rails 3.2.5, so this PR just upgrades Rails to the latest patch version for security fixes.